### PR TITLE
Arruma bug push de orders is None

### DIFF
--- a/tradingsystem.py
+++ b/tradingsystem.py
@@ -47,6 +47,8 @@ class TradingSystem():
                 self.listeners[instrument].append(strategy.id)
 
     def submit(self, id, orders):
+        if orders is None:
+            orders = []
 
         for order in orders:
 


### PR DESCRIPTION
Quando um return de um push de orders feito por um objeto `Strategy` for `None`, o método `submit` da classe `TradingSystem` utiliza orders como uma lista vazia.

``` python
def submit(self, id, orders):
        if orders is None:
            orders = []

        for order in orders:
        #...
```